### PR TITLE
feat: Add email notification support for scheduled tasks

### DIFF
--- a/next/app/schedules/page.tsx
+++ b/next/app/schedules/page.tsx
@@ -23,6 +23,7 @@ export default function SchedulesPage() {
   const [aiProvider, setAiProvider] = useState('gemini');
   const [enableWebSearch, setEnableWebSearch] = useState(false);
   const [notificationType, setNotificationType] = useState('discord');
+  const [notificationEmail, setNotificationEmail] = useState('');
   const [cronPreset, setCronPreset] = useState('0 0 9 * * ?');
   const [cronExpression, setCronExpression] = useState('0 0 9 * * ?');
   const [startDate, setStartDate] = useState('');
@@ -60,6 +61,7 @@ export default function SchedulesPage() {
         aiProvider,
         enableWebSearch,
         notificationType,
+        notificationEmail: notificationEmail || undefined,
         cronExpression,
         startDate: startDate || undefined,
         endDate: endDate || undefined,
@@ -70,6 +72,7 @@ export default function SchedulesPage() {
       setAiProvider('gemini');
       setEnableWebSearch(false);
       setNotificationType('discord');
+      setNotificationEmail('');
       setCronExpression('0 0 9 * * ?');
       setCronPreset('0 0 9 * * ?');
       setStartDate('');
@@ -187,9 +190,24 @@ export default function SchedulesPage() {
                 className="w-full px-4 py-2 bg-black border border-zinc-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
               >
                 <option value="discord">Discord</option>
-                <option value="email">Email (Coming Soon)</option>
+                <option value="email">Email</option>
               </select>
             </div>
+
+            {notificationType === 'email' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-2">Email Address</label>
+                <input
+                  type="email"
+                  value={notificationEmail}
+                  onChange={(e) => setNotificationEmail(e.target.value)}
+                  placeholder="your.email@example.com"
+                  className="w-full px-4 py-2 bg-black border border-zinc-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  required={notificationType === 'email'}
+                />
+                <p className="text-xs text-gray-500 mt-1">Task results will be sent to this email address</p>
+              </div>
+            )}
 
             <div>
               <label className="block text-sm font-medium text-gray-300 mb-2">Schedule Preset</label>

--- a/next/lib/api.ts
+++ b/next/lib/api.ts
@@ -62,6 +62,8 @@ export interface Schedule {
   prompt: string;
   aiProvider: string;
   enableWebSearch: boolean;
+  notificationType: string;
+  notificationEmail: string | null;
   cronExpression: string;
   startDate: string | null;
   endDate: string | null;
@@ -78,6 +80,7 @@ export interface ScheduleRequest {
   aiProvider?: string;
   enableWebSearch?: boolean;
   notificationType?: string;
+  notificationEmail?: string;
   cronExpression: string;
   startDate?: string;
   endDate?: string;

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/spring/src/main/java/devacc11011/spring/dto/TaskRequest.java
+++ b/spring/src/main/java/devacc11011/spring/dto/TaskRequest.java
@@ -16,4 +16,5 @@ public class TaskRequest {
 	private String aiProvider;
 	private Boolean enableWebSearch;
 	private String notificationType;
+	private String notificationEmail;
 }

--- a/spring/src/main/java/devacc11011/spring/entity/Schedule.java
+++ b/spring/src/main/java/devacc11011/spring/entity/Schedule.java
@@ -46,6 +46,9 @@ public class Schedule {
 	@Builder.Default
 	private String notificationType = "discord";
 
+	@Column(name = "notification_email", length = 255)
+	private String notificationEmail;
+
 	@Column(name = "cron_expression", nullable = false, length = 100)
 	private String cronExpression;
 

--- a/spring/src/main/java/devacc11011/spring/entity/Task.java
+++ b/spring/src/main/java/devacc11011/spring/entity/Task.java
@@ -48,6 +48,9 @@ public class Task {
 	@Builder.Default
 	private String notificationType = "discord";
 
+	@Column(name = "notification_email", length = 255)
+	private String notificationEmail;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;

--- a/spring/src/main/java/devacc11011/spring/job/ScheduledTaskJob.java
+++ b/spring/src/main/java/devacc11011/spring/job/ScheduledTaskJob.java
@@ -73,6 +73,7 @@ public class ScheduledTaskJob implements Job {
 				.aiProvider(schedule.getAiProvider())
 				.enableWebSearch(schedule.getEnableWebSearch())
 				.notificationType(schedule.getNotificationType())
+				.notificationEmail(schedule.getNotificationEmail())
 				.build();
 
 			newTask = taskService.createTask(taskRequest, schedule.getUser());

--- a/spring/src/main/java/devacc11011/spring/service/EmailNotificationService.java
+++ b/spring/src/main/java/devacc11011/spring/service/EmailNotificationService.java
@@ -3,6 +3,7 @@ package devacc11011.spring.service;
 import devacc11011.spring.entity.Task;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service("emailNotificationService")
@@ -10,10 +11,14 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class EmailNotificationService implements NotificationService {
 
+	private final EmailService emailService;
+
+	@Value("${spring.mail.username:}")
+	private String mailUsername;
+
 	@Override
 	public boolean isEnabled() {
-		// TODO: 이메일 설정 확인
-		return false;
+		return mailUsername != null && !mailUsername.isEmpty();
 	}
 
 	@Override
@@ -23,7 +28,63 @@ public class EmailNotificationService implements NotificationService {
 
 	@Override
 	public void sendTaskCompletionNotification(Task task) {
-		// TODO: 이메일 전송 구현
-		log.info("Email notification not yet implemented for task: {}", task.getId());
+		if (!isEnabled()) {
+			log.warn("Email notification is not enabled. Skipping notification for task: {}", task.getId());
+			return;
+		}
+
+		// Task에 연결된 사용자의 이메일이 있으면 전송
+		String userEmail = task.getUser() != null ? task.getUser().getEmail() : null;
+		if (userEmail == null || userEmail.isEmpty()) {
+			log.warn("No email address found for user. Skipping notification for task: {}", task.getId());
+			return;
+		}
+
+		try {
+			boolean isSuccess = "COMPLETED".equals(task.getStatus());
+			String result = task.getResult() != null ? task.getResult() : "No result available";
+
+			emailService.sendTaskResultEmail(
+				userEmail,
+				task.getTitle(),
+				result,
+				isSuccess
+			);
+
+			log.info("Email notification sent successfully to {} for task: {}", userEmail, task.getId());
+		} catch (Exception e) {
+			log.error("Failed to send email notification for task: {}", task.getId(), e);
+		}
+	}
+
+	/**
+	 * 특정 이메일 주소로 알림 전송
+	 */
+	public void sendTaskCompletionNotification(Task task, String emailAddress) {
+		if (!isEnabled()) {
+			log.warn("Email notification is not enabled. Skipping notification for task: {}", task.getId());
+			return;
+		}
+
+		if (emailAddress == null || emailAddress.isEmpty()) {
+			log.warn("No email address provided. Skipping notification for task: {}", task.getId());
+			return;
+		}
+
+		try {
+			boolean isSuccess = "COMPLETED".equals(task.getStatus());
+			String result = task.getResult() != null ? task.getResult() : "No result available";
+
+			emailService.sendTaskResultEmail(
+				emailAddress,
+				task.getTitle(),
+				result,
+				isSuccess
+			);
+
+			log.info("Email notification sent successfully to {} for task: {}", emailAddress, task.getId());
+		} catch (Exception e) {
+			log.error("Failed to send email notification to {} for task: {}", emailAddress, task.getId(), e);
+		}
 	}
 }

--- a/spring/src/main/java/devacc11011/spring/service/EmailService.java
+++ b/spring/src/main/java/devacc11011/spring/service/EmailService.java
@@ -1,0 +1,136 @@
+package devacc11011.spring.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+
+	private final JavaMailSender mailSender;
+
+	@Value("${spring.mail.username}")
+	private String fromEmail;
+
+	public void sendTaskResultEmail(String toEmail, String taskTitle, String result, boolean isSuccess) {
+		try {
+			MimeMessage message = mailSender.createMimeMessage();
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+			helper.setFrom(fromEmail);
+			helper.setTo(toEmail);
+			helper.setSubject(buildSubject(taskTitle, isSuccess));
+			helper.setText(buildHtmlContent(taskTitle, result, isSuccess), true);
+
+			mailSender.send(message);
+			log.info("Email sent successfully to: {}", toEmail);
+		} catch (MessagingException e) {
+			log.error("Failed to send email to: {}", toEmail, e);
+			throw new RuntimeException("Failed to send email", e);
+		}
+	}
+
+	private String buildSubject(String taskTitle, boolean isSuccess) {
+		String status = isSuccess ? "✅ Success" : "❌ Failed";
+		return String.format("[ACron] %s - %s", status, taskTitle);
+	}
+
+	private String buildHtmlContent(String taskTitle, String result, boolean isSuccess) {
+		String statusColor = isSuccess ? "#10b981" : "#ef4444";
+		String statusText = isSuccess ? "Successfully Completed" : "Execution Failed";
+		String statusIcon = isSuccess ? "✅" : "❌";
+
+		return String.format("""
+			<!DOCTYPE html>
+			<html>
+			<head>
+			    <meta charset="UTF-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+			</head>
+			<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #0a0a0a;">
+			    <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+			        <!-- Header -->
+			        <div style="text-align: center; padding: 30px 0;">
+			            <h1 style="color: #ffffff; font-size: 28px; margin: 0; font-weight: 700;">
+			                ACron Scheduler
+			            </h1>
+			            <p style="color: #71717a; margin: 10px 0 0 0; font-size: 14px;">
+			                Task Execution Report
+			            </p>
+			        </div>
+
+			        <!-- Content Card -->
+			        <div style="background: linear-gradient(to bottom, #18181b, #09090b); border: 1px solid #27272a; border-radius: 12px; padding: 30px; margin: 20px 0;">
+			            <!-- Status Badge -->
+			            <div style="text-align: center; margin-bottom: 30px;">
+			                <div style="display: inline-block; padding: 8px 20px; background-color: %s; border-radius: 20px;">
+			                    <span style="color: #ffffff; font-size: 14px; font-weight: 600;">
+			                        %s %s
+			                    </span>
+			                </div>
+			            </div>
+
+			            <!-- Task Title -->
+			            <div style="margin-bottom: 25px;">
+			                <h2 style="color: #a1a1aa; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 8px 0;">
+			                    Task Name
+			                </h2>
+			                <p style="color: #ffffff; font-size: 18px; font-weight: 600; margin: 0;">
+			                    %s
+			                </p>
+			            </div>
+
+			            <!-- Divider -->
+			            <div style="height: 1px; background-color: #27272a; margin: 25px 0;"></div>
+
+			            <!-- Result -->
+			            <div>
+			                <h2 style="color: #a1a1aa; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 12px 0;">
+			                    Execution Result
+			                </h2>
+			                <div style="background-color: #09090b; border: 1px solid #27272a; border-radius: 8px; padding: 16px; max-height: 400px; overflow-y: auto;">
+			                    <pre style="color: #e4e4e7; font-family: 'Courier New', monospace; font-size: 13px; line-height: 1.6; margin: 0; white-space: pre-wrap; word-wrap: break-word;">%s</pre>
+			                </div>
+			            </div>
+			        </div>
+
+			        <!-- Footer -->
+			        <div style="text-align: center; padding: 20px 0;">
+			            <p style="color: #52525b; font-size: 12px; margin: 0;">
+			                This is an automated notification from ACron Scheduler
+			            </p>
+			            <p style="color: #52525b; font-size: 12px; margin: 5px 0 0 0;">
+			                <a href="https://acron.lisan-al-gaib.top" style="color: #6366f1; text-decoration: none;">Visit ACron</a>
+			            </p>
+			        </div>
+			    </div>
+			</body>
+			</html>
+			""",
+			statusColor,
+			statusIcon,
+			statusText,
+			escapeHtml(taskTitle),
+			escapeHtml(result)
+		);
+	}
+
+	private String escapeHtml(String text) {
+		if (text == null) {
+			return "";
+		}
+		return text
+			.replace("&", "&amp;")
+			.replace("<", "&lt;")
+			.replace(">", "&gt;")
+			.replace("\"", "&quot;")
+			.replace("'", "&#39;");
+	}
+}

--- a/spring/src/main/java/devacc11011/spring/service/TaskService.java
+++ b/spring/src/main/java/devacc11011/spring/service/TaskService.java
@@ -63,6 +63,7 @@ public class TaskService {
 			.aiProvider(provider)
 			.enableWebSearch(enableWebSearch)
 			.notificationType(notificationType)
+			.notificationEmail(request.getNotificationEmail())
 			.user(user)
 			.build();
 
@@ -128,7 +129,13 @@ public class TaskService {
 		try {
 			NotificationService notificationService = notificationServiceFactory.getNotificationService(task.getNotificationType());
 			if (notificationService.isEnabled()) {
-				notificationService.sendTaskCompletionNotification(task);
+				// 이메일 알림인 경우 notificationEmail 필드 사용
+				if ("email".equals(task.getNotificationType()) && task.getNotificationEmail() != null && !task.getNotificationEmail().isEmpty()) {
+					EmailNotificationService emailService = (EmailNotificationService) notificationService;
+					emailService.sendTaskCompletionNotification(task, task.getNotificationEmail());
+				} else {
+					notificationService.sendTaskCompletionNotification(task);
+				}
 			} else {
 				log.warn("Notification service {} is not enabled", task.getNotificationType());
 			}

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -55,6 +55,23 @@ spring:
         format_sql: ${JPA_FORMAT_SQL:false}
         dialect: org.hibernate.dialect.MySQLDialect
 
+  mail:
+    host: ${MAIL_HOST:smtp.gmail.com}
+    port: ${MAIL_PORT:587}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    default-encoding: UTF-8
+
 gemini:
   api:
     key: ${GEMINI_API_KEY}

--- a/spring/src/test/resources/application-test.yml
+++ b/spring/src/test/resources/application-test.yml
@@ -35,6 +35,19 @@ spring:
             user-info-uri: https://discord.com/api/users/@me
             user-name-attribute: id
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: test@example.com
+    password: test-password
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
 app:
   frontend:
     url: http://localhost:3000


### PR DESCRIPTION
Implemented email notification feature as an alternative to Discord notifications:

Backend changes:
- Added spring-boot-starter-mail dependency
- Implemented EmailService with HTML template for task results
- Enhanced EmailNotificationService to support custom email addresses
- Extended Task and Schedule entities with notificationEmail field
- Updated TaskService to handle email notifications with custom addresses
- Modified ScheduledTaskJob to pass email information to tasks
- Added email configuration in application.yml
- Updated test configuration with email settings

Frontend changes:
- Updated Schedule and ScheduleRequest types with notificationEmail field
- Modified schedules form to support email notification type
- Added conditional email input field when email notification is selected
- Changed "Email (Coming Soon)" to "Email" option

Users can now choose between Discord and Email notifications for their scheduled tasks. When selecting email, they can specify a custom email address to receive task results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)